### PR TITLE
告知欄の追加・更新

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,6 +151,13 @@ layout: home
   <a href="https://tokyo-characterstreet.athree3pr.com/sana-sanrio/?utm_source=twitter&utm_medium=social&utm_campaign=20220303_NTSS"><i class="fas fa-external-link-alt"></i>コラボ詳細はこちら</a>
   <a href="https://e-shop.tokyoeki-1bangai.co.jp/shop/e/eNSSANRIO/"><i class="fas fa-external-link-alt"></i>通販ページはこちら（3月4日〜3月17日まで</a>
 </p>
+<p>
+  <span>『TOWER RECORDS 川崎店 × さなのばくたん。』今年も開催！（2022年3月4日〜27日 ※関連商品の販売は7日から）</span>
+  <br>
+  <a href="https://twitter.com/TOWER_Kawasaki"><i class="fas fa-external-link-alt"></i>タワーレコード川崎店公式Twitter</a>
+  <a href="https://twitter.com/37bakutan/status/1497552897164574722"><i class="fas fa-external-link-alt"></i>イラストパネル展示＆アルバム販売予定</a>
+  <a href="https://twitter.com/TOWER_Kawasaki/status/1497768306513973249"><i class="fas fa-external-link-alt"></i>さなコレVol.1の再販も予定</a>
+</p>
 
 <hr style="margin: 1em 0 ;">
 　<span class="important-notify"><b>『うめともものふつうの暮らし③』ゲストページにイラスト寄稿！（11/30発売）</b></span>

--- a/index.html
+++ b/index.html
@@ -115,12 +115,15 @@ layout: home
   <a href="https://www.youtube.com/watch?v=4Wj9YQgm_94"><i class="fas fa-external-link-alt"></i>さな歩き完全版(2021)</a>
 </p>
 <p>
-  <span>『さなのばくたん。×LA CITTADELLA』コラボ企画進行中！</span>
+  <span>さなのばくたん。レストラン開催中！（2022年3月4日〜27日 営業時間11:00〜20:00）</span>
   <br>
   <button type="button" class="sounds" data-file="すごいお知らせのある名取さなさんと話そう/ばくたん×LA_CITTADELLAコラボ企画進行中！">ばくたん×LA CITTADELLAコラボ企画進行中！</button>
   <button type="button" class="sounds" data-file="すごいお知らせのある名取さなさんと話そう/詳細は後日発表予定">詳細は後日発表予定</button>
   <br>
-  <a href="https://lacittadella.co.jp/">ラ チッタデッラ公式ページはこちら</a>
+  <a href="https://lacittadella.co.jp/"><i class="fas fa-external-link-alt"></i>ラ チッタデッラ公式ページはこちら</a>
+  <a href="https://twitter.com/37bakutan/status/1497551638663659525"><i class="fas fa-external-link-alt"></i>＃ばくたんレストラン</a>
+  <a href="https://twitter.com/37bakutan/status/1497552302047391745"><i class="fas fa-external-link-alt"></i>コラボカフェ実施概要</a>
+  <a href="https://twitter.com/37bakutan/status/1497552314986803204"><i class="fas fa-external-link-alt"></i>食べ歩きスタンプラリーも開催！</a>
 </p>
 <p>
   <span>『名取さな×サンリオキャラクターズ』コラボ決定！</span>

--- a/index.html
+++ b/index.html
@@ -126,6 +126,13 @@ layout: home
   <a href="https://twitter.com/37bakutan/status/1497552314986803204"><i class="fas fa-external-link-alt"></i>食べ歩きスタンプラリーも開催！</a>
 </p>
 <p>
+  <span>『HillValley × さなのばくたん。』開催中！（2022年3月4日〜27日）</span>
+  <br>
+  <a href="https://twitter.com/hillvalley_4"><i class="fas fa-external-link-alt"></i>ヒルバレー公式Twitter</a>
+  <a href="https://twitter.com/37bakutan/status/1497552731329892353"><i class="fas fa-external-link-alt"></i>詳細はこちら</a>
+  <a href="https://twitter.com/sana_natori/status/1497564270418006019"><i class="fas fa-external-link-alt"></i>HillValley × もごご</a>
+</p>
+<p>
   <span>『名取さな×サンリオキャラクターズ』コラボ決定！</span>
   <br>
   <button type="button" class="sounds" data-file="すごいお知らせのある名取さなさんと話そう/名取さな×サンリオキャラクターズコラボ決定！">名取さな×サンリオキャラクターズコラボ決定！</button>

--- a/index.html
+++ b/index.html
@@ -110,6 +110,12 @@ layout: home
   <a href="https://twitter.com/37bakutan/status/1489158873571225602"><i class="fas fa-external-link-alt"></i>さな歩き#1</a>
   <a href="https://twitter.com/37bakutan/status/1490959415335620614"><i class="fas fa-external-link-alt"></i>さな歩き#2</a>
   <a href="https://twitter.com/37bakutan/status/1491705242253025280"><i class="fas fa-external-link-alt"></i>さな歩き#3</a>
+  <a href="https://twitter.com/37bakutan/status/1494567359880876050"><i class="fas fa-external-link-alt"></i>さな歩き#4</a>
+  <a href="https://twitter.com/37bakutan/status/1496105786711617538"><i class="fas fa-external-link-alt"></i>さな歩き#5</a>
+  <a href="https://twitter.com/37bakutan/status/1498591372630052864"><i class="fas fa-external-link-alt"></i>さな歩き#6</a>
+  <a href="https://twitter.com/37bakutan/status/1498841017180688385"><i class="fas fa-external-link-alt"></i>さな歩き#7</a>
+  <a href="https://twitter.com/37bakutan/status/1499250464944271361"><i class="fas fa-external-link-alt"></i>さな歩き#8</a>
+  <a href="https://twitter.com/37bakutan/status/1499631475586523139"><i class="fas fa-external-link-alt"></i>さな歩き#9</a>
   <br>
   <a href="https://twitter.com/i/events/1360226068930564099"><i class="fas fa-external-link-alt"></i>さな歩きモーメント(2021)</a>
   <a href="https://www.youtube.com/watch?v=4Wj9YQgm_94"><i class="fas fa-external-link-alt"></i>さな歩き完全版(2021)</a>

--- a/index.html
+++ b/index.html
@@ -99,6 +99,13 @@ layout: home
   <a href="https://twitter.com/37bakutan/status/1471416221946245131"><i class="fas fa-external-link-alt"></i>グッズ⑦メチャ・ハッピー・生誕記念クリアポスター</a>
   <br>
   <a href="https://www.youtube.com/watch?v=TfMhTyCA3r8"><i class="fas fa-external-link-alt"></i>ティザーPVはこちら</a>
+  <br>
+  <a href="https://twitter.com/37bakutan/status/1497553239356874757"><i class="fas fa-external-link-alt"></i>追加グッズ①さなコレVol.2</a>
+  <a href="https://twitter.com/37bakutan/status/1498986548645478403"><i class="fas fa-external-link-alt"></i>追加グッズ②イベントパンフレット</a>
+  <a href="https://twitter.com/37bakutan/status/1498987171499614209"><i class="fas fa-external-link-alt"></i>当日物販情報はこちら</a>
+  <br>
+  <a href="https://twitter.com/37bakutan/status/1498991817878310914"><i class="fas fa-external-link-alt"></i>当日チケット販売決定！</a>
+  <a href="https://twitter.com/37bakutan/status/1499664294622892032"><i class="fas fa-external-link-alt"></i>イベントで使うかもしれない事前アンケートはこちら（回答期限：3月6日18:00まで</a>
 </p>
 
 <hr style="margin: 1em 0 ;">

--- a/index.html
+++ b/index.html
@@ -200,7 +200,7 @@ layout: home
 <p>
   <a href="https://twitter.com/sana_natori/status/1458022445378510849"><i class="fas fa-external-link-alt"></i>今回はステッカーが貰える！</a>
   <a href="https://twitter.com/sana_natori/status/1458279146287611915"><i class="fas fa-external-link-alt"></i>2022年3月まで月1回程度実施予定</a>
-  <a href="https://www.city.natori.miyagi.jp/soshiki/kenkou/hokenc/node_74390/node_84038"><i class="fas fa-external-link-alt"></i>詳細はこちら（次回開催：2月26日）</a>
+  <a href="https://www.city.natori.miyagi.jp/soshiki/kenkou/hokenc/node_74390/node_84038"><i class="fas fa-external-link-alt"></i>詳細はこちら（次回開催：3月19日・26日）</a>
   <br>
   <a href="https://www.bs.jrc.or.jp/th/miyagi/place/m1_03_bus.html?selectarea=%E5%90%8D%E5%8F%96%E5%B8%82&selectday=-">名取市内献血バスの運行スケジュールはこちら（コラボ対象外の日もあるので注意）</a>
   <a href="https://www.bs.jrc.or.jp/th/miyagi/donation/m2_01_02_01_show.html">献血基準表はこちら</a>

--- a/index.html
+++ b/index.html
@@ -250,6 +250,7 @@ layout: home
   <a href="https://natorisana.fanbox.cc/posts/3046976"><i class="fas fa-external-link-alt"></i>第8食</a>
   <a href="https://natorisana.fanbox.cc/posts/3182879"><i class="fas fa-external-link-alt"></i>第9食</a>
   <a href="https://natorisana.fanbox.cc/posts/3321036"><i class="fas fa-external-link-alt"></i>第10食</a>
+  <a href="https://natorisana.fanbox.cc/posts/3469930"><i class="fas fa-external-link-alt"></i>第11食（無料公開）</a>
 </p>
 <p>
   <a href="https://twitter.com/sana_natori/status/1386323276712988674"><i class="fas fa-external-link-alt"></i>感想は#もごご</a>

--- a/index.html
+++ b/index.html
@@ -158,6 +158,12 @@ layout: home
   <a href="https://twitter.com/37bakutan/status/1497552897164574722"><i class="fas fa-external-link-alt"></i>イラストパネル展示＆アルバム販売予定</a>
   <a href="https://twitter.com/TOWER_Kawasaki/status/1497768306513973249"><i class="fas fa-external-link-alt"></i>さなコレVol.1の再販も予定</a>
 </p>
+<p>
+  <span>『ローソンプリントコラボ』今年も開催！（2022年3月4日〜31日）</span>
+  <br>
+  <a href="https://twitter.com/37bakutan/status/1498222799814467584"><i class="fas fa-external-link-alt"></i>ローソンプリントコラボ実施決定！（全12種）</a>
+  <a href="https://twitter.com/lawsonmulticopy/status/1499550227115749376"><i class="fas fa-external-link-alt"></i>今年は好きな絵柄を選べる</a>
+</p>
 
 <hr style="margin: 1em 0 ;">
 　<span class="important-notify"><b>『うめともものふつうの暮らし③』ゲストページにイラスト寄稿！（11/30発売）</b></span>

--- a/index.html
+++ b/index.html
@@ -138,6 +138,8 @@ layout: home
   <br>
   <a href="https://twitter.com/sanrioanist"><i class="fas fa-external-link-alt"></i>サンリオアニメストア公式Twitter</a>
   <a href="https://twitter.com/sanrioanist/status/1492106308505731074"><i class="fas fa-external-link-alt"></i>場所：東京キャラクターストリートG階段下ワゴンショップ　期間：2022年3月4日～17日</a>
+  <a href="https://tokyo-characterstreet.athree3pr.com/sana-sanrio/?utm_source=twitter&utm_medium=social&utm_campaign=20220303_NTSS"><i class="fas fa-external-link-alt"></i>コラボ詳細はこちら</a>
+  <a href="https://e-shop.tokyoeki-1bangai.co.jp/shop/e/eNSSANRIO/"><i class="fas fa-external-link-alt"></i>通販ページはこちら（3月4日〜3月17日まで</a>
 </p>
 
 <hr style="margin: 1em 0 ;">


### PR DESCRIPTION
・告知欄更新
サンリオコラボの告知欄を更新
ばくたんレストランの告知欄を追加（ラチッタデッラコラボの告知欄を修正）
ヒルバレーコラボの告知欄を追加
タワレココラボの告知欄を追加
ローソンプリントコラボの告知欄を追加
さな歩きの告知欄を更新
ばくたん2022の告知欄を更新
もごごの告知欄を更新
献血コラボの告知欄を更新

ボタン追加する余裕が無かったので今回は告知のみの更新になります🙇‍♂️