### PR TITLE
2021年爆誕の情報を過去のイベントページにコピー

### DIFF
--- a/events.html
+++ b/events.html
@@ -6,6 +6,75 @@ layout: default
 </div>
 
 <hr style="margin: 1em 0 ;">
+　<span class="important-notify"><b>『さなのばくたん。 -メチャ・ハッピー・ショー-』2022年3月7日開催決定！</b></span>
+<br>
+<button type="button" class="sounds" data-file="3Dアプデ披露重大発表ぜ～んぶやる/さなのばくたん。来年もやるぜ〜〜〜！！">さなのばくたん。来年もやるぜ〜〜〜！！</button>
+<button type="button" class="sounds" data-file="3Dアプデ披露重大発表ぜ～んぶやる/さなのばくたん。メチャ・ハッピー・ショー_Powered_by_mouse開催！">さなのばくたん。-メチャ・ハッピー・ショー- Powered by mouse開催！</button>
+<button type="button" class="sounds" data-file="3Dアプデ披露重大発表ぜ～んぶやる/ばくたんスタッフはずっと一緒だからやりやすい">ばくたんスタッフはずっと一緒だからやりやすい</button>
+<button type="button" class="sounds" data-file="3Dアプデ披露重大発表ぜ～んぶやる/来年のスクリーン数はなんと・・・">来年のスクリーン数はなんと・・・</button>
+<button type="button" class="sounds" data-file="3Dアプデ披露重大発表ぜ～んぶやる/詳しくはばくたんTwitterを要チェック">詳しくはばくたんTwitterを要チェック</button>
+<button type="button" class="sounds" data-file="3Dアプデ披露重大発表ぜ～んぶやる/オンライン配信はZaNにて予定">オンライン配信はZaNにて予定</button>
+<button type="button" class="sounds" data-file="3Dアプデ披露重大発表ぜ～んぶやる/デザイン：clocknoteせんせえ">デザイン：clocknote.せんせえ</button>
+<button type="button" class="sounds" data-file="3Dアプデ披露重大発表ぜ～んぶやる/グッズ事前通販あります">グッズ事前通販あります</button>
+<button type="button" class="sounds" data-file="3Dアプデ披露重大発表ぜ～んぶやる/グッズ通販：eeo_store">グッズ通販：eeo store</button>
+<br>
+<button type="button" class="sounds" data-file="こりゎなんだ？雑に話すぞい/グッズ①増殖するうさちゃんせんせえ細胞Tシャツ">グッズ①増殖するうさちゃんせんせえ細胞Tシャツ</button>
+<button type="button" class="sounds" data-file="こりゎなんだ？雑に話すぞい/今回の「凝り」">今回の「凝り」</button>
+<button type="button" class="sounds" data-file="こりゎなんだ？雑に話すぞい/うさちゃんせんせえの汎用性">うさちゃんせんせえの汎用性</button>
+<button type="button" class="sounds" data-file="こりゎなんだ？雑に話すぞい/首の後ろのタグが印刷になってる">首の後ろのタグが印刷になってる</button>
+<button type="button" class="sounds" data-file="こりゎなんだ？雑に話すぞい/細胞T商品説明">細胞T商品説明</button>
+<button type="button" class="sounds" data-file="こりゎなんだ？雑に話すぞい/グッズ②さなちゃんねるキャラクターズ大集合タオル">グッズ②さなちゃんねるキャラクターズ大集合タオル</button>
+<button type="button" class="sounds" data-file="こりゎなんだ？雑に話すぞい/今治タオルはタオル界No1">今治タオルはタオル界No1</button>
+<button type="button" class="sounds" data-file="こりゎなんだ？雑に話すぞい/グッズ③さなちゃんねる王国謹製ピカピカブレード">グッズ③さなちゃんねる王国謹製ピカピカブレード</button>
+<button type="button" class="sounds" data-file="こりゎなんだ？雑に話すぞい/足りるとは思うけど数に限りがあるので注意">足りるとは思うけど数に限りがあるので注意</button>
+<button type="button" class="sounds" data-file="こりゎなんだ？雑に話すぞい/色の種類は全12色">色の種類は全12色</button>
+<button type="button" class="sounds" data-file="こりゎなんだ？雑に話すぞい/色で感情表現してた話">色で感情表現してた話</button>
+<button type="button" class="sounds" data-file="こりゎなんだ？雑に話すぞい/グッズ④おでかけさなちゃんサコッシュ">グッズ④おでかけさなちゃんサコッシュ</button>
+<button type="button" class="sounds" data-file="こりゎなんだ？雑に話すぞい/サコッシュ商品説明">サコッシュ商品説明</button>
+<button type="button" class="sounds" data-file="こりゎなんだ？雑に話すぞい/グッズ⑤さなちゃんねる王国ラゲッジタグ">グッズ⑤さなちゃんねる王国ラゲッジタグ</button>
+<button type="button" class="sounds" data-file="こりゎなんだ？雑に話すぞい/ラゲッジタグとは">ラゲッジタグとは</button>
+<button type="button" class="sounds" data-file="こりゎなんだ？雑に話すぞい/入国許可証付き">入国許可証付き</button>
+<button type="button" class="sounds" data-file="こりゎなんだ？雑に話すぞい/素材はPVC">素材はPVC</button>
+<button type="button" class="sounds" data-file="こりゎなんだ？雑に話すぞい/文字は名取が考えた">文字は名取が考えた</button>
+<button type="button" class="sounds" data-file="こりゎなんだ？雑に話すぞい/ラゲッジタグ商品説明">ラゲッジタグ商品説明</button>
+<button type="button" class="sounds" data-file="こりゎなんだ？雑に話すぞい/グッズ⑥さなちゃんねるカレンダー2022">グッズ⑥さなちゃんねるカレンダー2022</button>
+<button type="button" class="sounds" data-file="こりゎなんだ？雑に話すぞい/ダジャレをじゃれ下ろし">ダジャレをじゃれ下ろし</button>
+<button type="button" class="sounds" data-file="こりゎなんだ？雑に話すぞい/さなちゃんねる王国は3月始まり">さなちゃんねる王国は3月始まり</button>
+<button type="button" class="sounds" data-file="こりゎなんだ？雑に話すぞい/カレンダーとしての役目を終えた後も表紙を飾れる">カレンダーとしての役目を終えた後も表紙を飾れる</button>
+<button type="button" class="sounds" data-file="こりゎなんだ？雑に話すぞい/グッズ⑦メチャ・ハッピー・生誕記念クリアポスター">グッズ⑦メチャ・ハッピー・生誕記念クリアポスター</button>
+<button type="button" class="sounds" data-file="こりゎなんだ？雑に話すぞい/クリアポスター商品説明">クリアポスター商品説明</button>
+<br>
+<button type="button" class="sounds" data-file="おいおいおいおいおいおい/プレスリリースに新衣装全体像あり">プレスリリースに新衣装全体像あり</button>
+<button type="button" class="sounds" data-file="おいおいおいおいおいおい/新曲「だじゃれくりえいしょん」">新曲「だじゃれくりえいしょん」</button>
+<button type="button" class="sounds" data-file="おいおいおいおいおいおい/色々準備中">色々準備中</button>
+<p>
+  <a href="https://bakutan.natorisana.com/"><i class="fas fa-external-link-alt"></i>ばくたん。公式サイトはこちら</a>
+  <a href="https://twitter.com/37bakutan"><i class="fas fa-external-link-alt"></i>ばくたん。公式Twitterはこちら</a>
+  <a href="https://twitter.com/sana_natori/status/1470012958332039168"><i class="fas fa-external-link-alt"></i>ハッシュタグは#名取爆誕</a>
+  <a href="https://twitter.com/37bakutan/status/1482189494233493507"><i class="fas fa-external-link-alt"></i>新3D衣装あります</a>
+  <a href="https://twitter.com/37bakutan/status/1482190967549890564"><i class="fas fa-external-link-alt"></i>新曲「だじゃれくりえぃしょん」制作決定！（作詞・作曲：やしきんせんせえ）</a>
+  <br>
+  <a href="https://eplus.jp/sf/detail/3364590001?P6=001&P1=0402&P59=1"><i class="fas fa-external-link-alt"></i>現地チケット購入（先行抽選）はこちら（受付期間：1/23 23:59まで）</a>
+  <a href="https://www.zan-live.com/live/detail/10143"><i class="fas fa-external-link-alt"></i>配信視聴ページ・チケット購入はこちら（チケット購入期間：3/28 23:59まで）</a>
+  <br>
+  <a href="https://eeo.today/store/101/title/search/product?parent_title_id=635"><i class="fas fa-external-link-alt"></i>イベントグッズ注文はこちら（eeo store：12/26まで）</a>
+  <a href="https://twitter.com/37bakutan/status/1471416183153106944"><i class="fas fa-external-link-alt"></i>グッズ①増殖するうさちゃんせんせえ細胞Tシャツ</a>
+  <a href="https://twitter.com/37bakutan/status/1471416190002409475"><i class="fas fa-external-link-alt"></i>グッズ②さなちゃんねるキャラクターズ大集合タオル</a>
+  <a href="https://twitter.com/37bakutan/status/1471416196520382466"><i class="fas fa-external-link-alt"></i>グッズ③さなちゃんねる王国謹製ピカピカブレード</a>
+  <a href="https://twitter.com/37bakutan/status/1471321249703886849"><i class="fas fa-external-link-alt"></i>ペンライトは数に限りがあるので注意</a>
+  <a href="https://twitter.com/37bakutan/status/1471416202568568834"><i class="fas fa-external-link-alt"></i>グッズ④おでかけさなちゃんサコッシュ</a>
+  <a href="https://twitter.com/37bakutan/status/1471416209086496768"><i class="fas fa-external-link-alt"></i>グッズ⑤さなちゃんねる王国ラゲッジタグ</a>
+  <a href="https://twitter.com/37bakutan/status/1471416215289856003"><i class="fas fa-external-link-alt"></i>グッズ⑥さなちゃんねるカレンダー2022</a>
+  <a href="https://twitter.com/37bakutan/status/1471416221946245131"><i class="fas fa-external-link-alt"></i>グッズ⑦メチャ・ハッピー・生誕記念クリアポスター</a>
+  <br>
+  <a href="https://www.youtube.com/watch?v=TfMhTyCA3r8"><i class="fas fa-external-link-alt"></i>ティザーPVはこちら</a>
+  <br>
+  <a href="https://twitter.com/37bakutan/status/1497553239356874757"><i class="fas fa-external-link-alt"></i>追加グッズ①さなコレVol.2</a>
+  <a href="https://twitter.com/37bakutan/status/1498986548645478403"><i class="fas fa-external-link-alt"></i>追加グッズ②イベントパンフレット</a>
+  <a href="https://twitter.com/37bakutan/status/1498987171499614209"><i class="fas fa-external-link-alt"></i>当日物販情報はこちら</a>
+</p>
+
+<hr style="margin: 1em 0 ;">
 　<span class="important-notify"><b>『名取とやひろのサンタクロース大作戦 〜プレゼント届くかな？〜』開催決定！（2021/12/25 開場19:30、開演20:00）</b></span>
 <br>
 <button type="button" class="sounds" data-file="3Dアプデ披露重大発表ぜ～んぶやる/＼名取とやひろの／サンタクロース大作戦開催！">名取とやひろのサンタクロース大作戦開催！</button>

--- a/index.html
+++ b/index.html
@@ -85,27 +85,10 @@ layout: home
   <a href="https://twitter.com/37bakutan/status/1482189494233493507"><i class="fas fa-external-link-alt"></i>新3D衣装あります</a>
   <a href="https://twitter.com/37bakutan/status/1482190967549890564"><i class="fas fa-external-link-alt"></i>新曲「だじゃれくりえぃしょん」制作決定！（作詞・作曲：やしきんせんせえ）</a>
   <br>
-  <a href="https://eplus.jp/sf/detail/3364590001?P6=001&P1=0402&P59=1"><i class="fas fa-external-link-alt"></i>現地チケット購入（先行抽選）はこちら（受付期間：1/23 23:59まで）</a>
   <a href="https://www.zan-live.com/live/detail/10143"><i class="fas fa-external-link-alt"></i>配信視聴ページ・チケット購入はこちら（チケット購入期間：3/28 23:59まで）</a>
   <br>
-  <a href="https://eeo.today/store/101/title/search/product?parent_title_id=635"><i class="fas fa-external-link-alt"></i>イベントグッズ注文はこちら（eeo store：12/26まで）</a>
-  <a href="https://twitter.com/37bakutan/status/1471416183153106944"><i class="fas fa-external-link-alt"></i>グッズ①増殖するうさちゃんせんせえ細胞Tシャツ</a>
-  <a href="https://twitter.com/37bakutan/status/1471416190002409475"><i class="fas fa-external-link-alt"></i>グッズ②さなちゃんねるキャラクターズ大集合タオル</a>
-  <a href="https://twitter.com/37bakutan/status/1471416196520382466"><i class="fas fa-external-link-alt"></i>グッズ③さなちゃんねる王国謹製ピカピカブレード</a>
-  <a href="https://twitter.com/37bakutan/status/1471321249703886849"><i class="fas fa-external-link-alt"></i>ペンライトは数に限りがあるので注意</a>
-  <a href="https://twitter.com/37bakutan/status/1471416202568568834"><i class="fas fa-external-link-alt"></i>グッズ④おでかけさなちゃんサコッシュ</a>
-  <a href="https://twitter.com/37bakutan/status/1471416209086496768"><i class="fas fa-external-link-alt"></i>グッズ⑤さなちゃんねる王国ラゲッジタグ</a>
-  <a href="https://twitter.com/37bakutan/status/1471416215289856003"><i class="fas fa-external-link-alt"></i>グッズ⑥さなちゃんねるカレンダー2022</a>
-  <a href="https://twitter.com/37bakutan/status/1471416221946245131"><i class="fas fa-external-link-alt"></i>グッズ⑦メチャ・ハッピー・生誕記念クリアポスター</a>
-  <br>
   <a href="https://www.youtube.com/watch?v=TfMhTyCA3r8"><i class="fas fa-external-link-alt"></i>ティザーPVはこちら</a>
-  <br>
-  <a href="https://twitter.com/37bakutan/status/1497553239356874757"><i class="fas fa-external-link-alt"></i>追加グッズ①さなコレVol.2</a>
-  <a href="https://twitter.com/37bakutan/status/1498986548645478403"><i class="fas fa-external-link-alt"></i>追加グッズ②イベントパンフレット</a>
-  <a href="https://twitter.com/37bakutan/status/1498987171499614209"><i class="fas fa-external-link-alt"></i>当日物販情報はこちら</a>
-  <br>
-  <a href="https://twitter.com/37bakutan/status/1498991817878310914"><i class="fas fa-external-link-alt"></i>当日チケット販売決定！</a>
-  <a href="https://twitter.com/37bakutan/status/1499664294622892032"><i class="fas fa-external-link-alt"></i>イベントで使うかもしれない事前アンケートはこちら（回答期限：3月6日18:00まで</a>
+  <a href="https://twitter.com/37bakutan/status/1500864595249885184"><i class="fas fa-external-link-alt"></i>だじゃれくりえぃしょん配信開始！</a> 
 </p>
 
 <hr style="margin: 1em 0 ;">


### PR DESCRIPTION
トップページにあるやつは、適宜消したりしていくけれど、こっちに都度での追加は不要（なはず）